### PR TITLE
Refresh + bug fixes - v2.0.2

### DIFF
--- a/freezer.bash
+++ b/freezer.bash
@@ -8,20 +8,23 @@ Compressing the current state.
 '
 #
 # <CONSTANTS>
-LOGHEADER="[TH][Freezer.sh]"
-DATE="$(date +"%Y-%m-%dT%H:%M")"
+LOGHEADER="[TH][Freezer]"
+DATE="$(date +"%Y-%m-%d")"
 STARTUP=$SECONDS
 ARGC=0
 ARGS=("$@")
 #
 # Log Func
 log() {
-    MSG="$LOGHEADER $1"
-    echo "$MSG"; logger "$MSG"
+    echo "$1"; logger "$LOGHEADER $1"
 }
 # Fail Check Function
 fc() {
     if [[ -n $1 ]]; then log "$2 ErrorMsg($1)"; exit 1; fi
+}
+# Fail Check - NO KILL - Function
+fcnk() {
+    if [[ -n $1 ]]; then log "$2 ErrorMsg($1)"; fi
 }
 # Empty Check Function
 ec() {
@@ -90,9 +93,9 @@ docker stop ${CURRENT_CONTAINERS}
 log "Starting Compression $( if [[ $PIGZ ]]; then echo "using pigz"; fi )"
 #
 if [[ $PIGZ ]]; then
-    fc "$(tar -c --use-compress-program=pigz -f "$TARGET/$DATE-docker.tar.gz" -C / "${SOURCE#/}/." 2>&1)" "[0x1] Compression with Pigz Failed!"
+    fcnk "$(tar -c --use-compress-program=pigz -f "$TARGET/$DATE-docker.tar.gz" -C / "${SOURCE#/}/." 2>&1)" "[0x1] Compression with Pigz Failed!"
 else
-    fc "$(tar -zcf "$TARGET/$DATE-docker.tar.gz" -C / "${SOURCE#/}/." 2>&1)" "[0x1] Compression Failed!"
+    fcnk "$(tar -zcf "$TARGET/$DATE-docker.tar.gz" -C / "${SOURCE#/}/." 2>&1)" "[0x1] Compression Failed!"
 fi
 log "Finished Compression"
 #

--- a/oculus.bash
+++ b/oculus.bash
@@ -8,7 +8,7 @@ Gathers a snapshot of the current state of the machine.
 '
 #
 # <CONSTANTS>
-LOGHEADER="[TH][Oculus.sh]"
+LOGHEADER="[TH][Oculus]"
 DATE="$(date +"%Y-%m-%dT%H:%M")"
 STARTUP=$SECONDS
 ARGC=0
@@ -17,12 +17,15 @@ TEMP_PATH="/tmp/th/oc/$DATE"
 #
 # Log Func
 log() {
-    MSG="$LOGHEADER $1"
-    echo "$MSG"; logger "$MSG"
+    echo "$1"; logger "$LOGHEADER $1"
 }
 # Fail Check Function
 fc() {
     if [[ -n $1 ]]; then log "$2 ErrorMsg($1)"; exit 1; fi
+}
+# Fail Check - NO KILL - Function
+fcnk() {
+    if [[ -n $1 ]]; then log "$2 ErrorMsg($1)"; fi
 }
 # Empty Check Function
 ec() {
@@ -106,7 +109,7 @@ log "System capture complete"
 # Compress run
 log "Starting compression"
 #
-fc "$(tar -zcf "$RUN_PATH/$DATE.tar.gz" -C / "${TEMP_PATH#/}" 2>&1)" "[0x1] Compression Failed!"
+fcnk "$(tar -zcf "$RUN_PATH/$DATE.tar.gz" -C / "${TEMP_PATH#/}" 2>&1)" "[0x1] Compression Failed!"
 rm -dr "$TEMP_PATH"
 log "Compression Complete"
 #

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,9 @@ Core Functions
 - [ ] Alerting
 - [x] Enforcement
 
-### Oculus
+---
+
+## Oculus
 
 Captures the output of multiple performance commands. Compresses the results. Rolls logs over every 14 days.
 
@@ -26,26 +28,64 @@ List of Commands:
 - nvidia-smi
 - zpool status
 ```bash
-Ex: bash oculus.bash -r [/path/to/dir] -R [Rollover Days] --ZFS --NVIDIA
+:$ bash oculus.bash -r [/path/to/dir] -R [Rollover Days] --ZFS --NVIDIA
 ```
 
-### Freezer
+---
+
+## Freezer
 
 Backs up and compresses the persistent data used by the Docker containers. Will require a brief outage to complete the backup.
 Script will temporarily STOP/START only the active containers. Ensuring inactive containers are not booted with the active ones. Rolls logs over every 14 days. **Pigz available as a multi-core solution instead of gzip for compression.**
 ```bash
-Ex: bash freezer.bash -s [/container/data] -t [/target/dir] [--pigz]
+:$ bash freezer.bash -s [/container/data] -t [/target/dir] [--pigz]
 ```
 
-### ~~Permission Check~~ 
+---
+
+## Refresh
+Destroys all resources in docker (containers, images, networks, etc), and rebuild from a defined set of build scripts. The purpose of this being to redeploy all containers with fresh, up-to-date images.
+```bash
+:$ bash refresh.bash -r [/runscripts] --CONFIRM
+```
+#### Run scripts
+The runscripts used by refresh must be within the following format to be used by the script effectively.
+```
+~/dockerscripts/
+  |-containers/
+    |- container1.sh
+    |- conatiner2.sh
+    |- ...
+  |-networks/
+    |- network1.sh
+    |- network2.sh
+```
+```bash
+# Example
+:$ bash refresh.bash -r ~/dockerscripts --CONFIRM
+```
+> Network scripts are ran first, then conatiners. If you have any containers, that are used like a network (Ex: gluetun) please put that run script in the *network/* directory.
+
+---
+
+## ~~Permission Check~~ 
 **Temporaily Deprecated** - *Lack of 'no-cobble' causes unintended modifications of compliant files. This breaks things like rollover that relies on last modified time. Script is not recommended to be ran until this is fixed in the next few updates. >2.0.0*
 
 ~~Sets the permissions of a directory. By default, chmod == 777 and owner+group == root.
 Running the script requires providing a directory path as an argument.~~
 ```bash
-Ex: bash perm_chk.sh [/path/to/dir] [owner] [chmod#]
+:$ bash perm_chk.sh [/path/to/dir] [owner] [chmod#]
 ```
+
+---
+
 ## Version History
+
+### Version 2.0.2 - *'Refresh + Bug fixes'*
++ [+] Added refresh.bash for cleaning docker, and maintaining up-to-date images
++ Fixed bugs on multiple scripts
+  + [tar-bug] Updated to Oculus and Freeze to avoid exiting when tar produces verbose. Tar does not properly implement stderr vs stdout for errors and info logging respectively.
+  + Updated logging to not prepend the service header for console logging. (Syslog/messages logging still shows the service header)
 
 ### Version 2.0.1 - *'Freezer Update'*
 + Merged freezer_MC and freezer using command-line arguments.

--- a/refresh.bash
+++ b/refresh.bash
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+: '
+refresh.bash
+
+Restarts and updates all docker conatiners
+
+'
+#
+#
+LOGHEADER="[TH][Refresh]"
+STARTUP=$SECONDS
+ARGC=0
+ARGS=("$@")
+#
+#
+# Log Func
+log() {
+    echo "$1"; logger "$LOGHEADER $1"
+}
+# Fail Check Function
+fc() {
+    if [[ -n $1 ]]; then log "$2 ErrorMsg($1)"; exit 1; fi
+}
+# Empty Check Function
+ec() {
+    if [[ -z $1 ]]; then log "$2"; exit 1; fi
+}
+# Run scripts BULK
+runbulk() {
+    for i in $( ls "$1"*.sh | grep -v DEP ); do
+        log "Recreating '$i'..."
+        bash "$i"
+    done
+}
+#
+# Parse Input Vars
+for ARG in "${ARGS[@]}"; do
+    case $ARG in
+    # Path to the docker run files (Rq)
+    "-r" | "--runscripts")
+        RUN_PATH=${ARGS[$ARGC+1]}
+    ;;
+    # Log Rotation (Opt)
+    "--CONFIRM")
+        CONFIRM=true
+    ;;
+    "-S" | "--silence")
+        SILENT=true
+    ;;
+    # Help menu
+    "-h" | "--help")
+        printf "Thunderhead - Refresh Help Menu\nWARNING! THIS SCRIPT CAN DESTROY ALL DOCKER DATA IF IMPROPERLY USED. YOU HAVE BEEN WARNED! ;p
+    -r --runscripts  Path to the scripts used to build the docker enviroment
+       --CONFIRM     Confirm running the operation (Required)
+    -S --silent      Silences the warning message at the begining of the run
+    -h --help        This menu\n"
+        exit
+    ;;
+    esac
+    # Iterate
+    ARGC=$(($ARGC + 1))
+done
+#
+# Input check and per-run warning
+ec "$RUN_PATH" "[0x1] No path to the run scripts provided. Please use -r or --runscripts."
+if [[ -z $SILENT ]]; then  echo "WARNING! THIS OPERATION WILL DESTROY ALL DOCKER DATA IF IMPROPERLY USED. YOU HAVE BEEN WARNED! ;p"; fi
+ec "$CONFIRM" "[0X1] '--CONFIRM' is required to run the script. Please add it to your command to continue."
+#
+# <Main>
+#
+log "Stoping Containers."
+docker stop $(docker ps -qa)
+#
+log "Pruning all docker data."
+docker system prune -fa
+#
+log "Rebuilding Docker Networks."
+runbulk "$RUN_PATH/networks/"
+#
+log "Rebuilding Docker Containers."
+runbulk "$RUN_PATH/containers/"
+#
+log "[0x0] Refresh completed successfully. Operation finished in ($(( $SECONDS - $STARTUP )))"


### PR DESCRIPTION
### Version 2.0.2 - *'Refresh + Bug fixes'*
+ [+] Added refresh.bash for cleaning docker, and maintaining up-to-date images
+ Fixed bugs on multiple scripts
  + [tar-bug] Updated to Oculus and Freeze to avoid exiting when tar produces verbose. Tar does not properly implement stderr vs stdout for errors and info logging respectively.
  + Updated logging to not prepend the service header for console logging. (Syslog/messages logging still shows the service header)