### PR TITLE
Updated to 2.0.5.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,9 @@ Running the script requires providing a directory path as an argument.~~
 
 ## Version History
 
+### Version 2.0.5.1 - *'VPN Check - fix'*
++ Fixed bug in vpn_chk.bash, that caused the IP pulled from the containers to always be the FAIL placeholder.
+
 ### Version 2.0.5 - *'The Rusty-Shackleford update'*
 + [+] Added vpn_chk.bash. This will check the complaince of containers that should be on VPN.
 

--- a/vpn_chk.bash
+++ b/vpn_chk.bash
@@ -42,15 +42,15 @@ for c in "${CONTS[@]}"; do
     log "Checking IP of container: $c, using curl..."
     #
     # First test - Curl
-    DIP=$(docker exec -ti "$c" "$CMD")
+    DIP=$(docker exec -ti "$c" $CMD)
     #
     # Second test - wget
-    if [[ "$DIP" != "*.*.*.*" ]]; then
+    if ! [[ "$DIP" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
         log "Using curl failed for conatiner: $c testing with wget..."
         DIP=$(wgetM "$c" "$URL")
     fi
     # Catchall
-    if [[ "$DIP" != "*.*.*.*" ]]; then
+    if ! [[ "$DIP" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
         log "Using both curl and wget failed for conatiner: $c skipping container..."
         DIP=FAIL
     fi


### PR DESCRIPTION
### Version 2.0.5.1 - *'VPN Check - fix'*
+ Fixed bug in vpn_chk.bash, that caused the IP pulled from the containers to always be the FAIL placeholder.