### PR TITLE
Updated to version 2.0.6.1

### DIFF
--- a/freezer.bash
+++ b/freezer.bash
@@ -232,10 +232,14 @@ else
         log "[Hard Reset] Rebuilding Containers and Networks using dir: $HARD"
         runbulk "$HARD/networks/"
         runbulk "$HARD/containers/"
-    else
-        # Regular restart of the containers
+    # Start stopped containers
+    elif [[ $RESET ]]; then
         log "Starting Containers"
         docker start ${CURRENT_CONTAINERS}
+    # Unpause
+    else
+        log "Unpausing Containers"
+        docker unpause ${CURRENT_CONTAINERS}
     fi
     #
     # Summary

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,9 @@ Running the script requires providing a directory path as an argument.~~
 
 ## Version History
 
+### Version 2.0.6.1 - *'Freezer-fix'*
++ Fixed bug with the new pause method for the backup. Logic error caused paused containers to be started via *docker start* instead of *docker unpause*
+
 ### Version 2.0.6 - *'Freezer + KVM'*
 + [+] Added KVM support to Freezer.bash.
   + -k or --kvm can be used to opt for KVM usage instead of docker


### PR DESCRIPTION
### Version 2.0.6.1 - *'Freezer-fix'*
+ Fixed bug with the new pause method for the backup. Logic error caused paused containers to be started via *docker start* instead of *docker unpause*